### PR TITLE
Consertando o registro de cartão de crédito

### DIFF
--- a/app/controllers/payment_methods_controller.rb
+++ b/app/controllers/payment_methods_controller.rb
@@ -32,7 +32,8 @@ class PaymentMethodsController < ApplicationController
   end
 
   def user_payment_method_params
-    user_params = params.require(:payment_method).permit(:payment_type, :card_number, :cvv_number, :expiry_date)
+    user_params = params.require(:payment_method).permit(:card_operator, :payment_type, :card_number, :cvv_number,
+                                                         :expiry_date)
     user_params.merge({ cpf: current_user.user_profile.cpf })
   end
 

--- a/app/models/payment_method.rb
+++ b/app/models/payment_method.rb
@@ -34,8 +34,7 @@ class PaymentMethod < ApplicationRecord
                                                 payment_type: @user_payment_method.payment_type } }
 
     if @user_payment_method.payment_type == 'credit_card'
-      credit_card_params = { card_number: @user_payment_method.card_number, cvv_number: @user_payment_method.cvv_number,
-                             expiry_date: @user_payment_method.expiry_date }
+      credit_card_params = set_credit_card
 
       payment_method_params[:payment_method].merge!(credit_card_params)
     end
@@ -61,5 +60,11 @@ class PaymentMethod < ApplicationRecord
   private_class_method def self.contains_error_message?(available_payment_methods)
     (available_payment_methods.is_a?(Array) && available_payment_methods&.first&.key?(:message)) ||
     (available_payment_methods.is_a?(Hash) && available_payment_methods&.key?(:message))
+  end
+
+  def set_credit_card
+    { card_number: @user_payment_method.card_number, cvv_number: @user_payment_method.cvv_number,
+      expiry_date: @user_payment_method.expiry_date,
+      card_operator: @user_payment_method.card_operator }
   end
 end

--- a/app/models/user_payment_method.rb
+++ b/app/models/user_payment_method.rb
@@ -1,5 +1,5 @@
 class UserPaymentMethod
-  attr_accessor :cpf, :payment_type, :card_number, :cvv_number, :expiry_date
+  attr_accessor :cpf, :payment_type, :card_number, :cvv_number, :expiry_date, :card_operator
   attr_reader :attribute_errors
 
   def initialize(params = {})
@@ -10,6 +10,7 @@ class UserPaymentMethod
 
     return unless @payment_type == 'credit_card'
 
+    @card_operator = params['card_operator'] || ''
     @card_number = params['card_number'] || ''
     @cvv_number = params['cvv_number'] || ''
     @expiry_date = params['expiry_date'] || ''

--- a/app/views/payment_methods/new.html.erb
+++ b/app/views/payment_methods/new.html.erb
@@ -13,7 +13,12 @@
 
     <div id='credit_card_fields'>
       <div class="form-floating mb-3">
-        <%= f.text_field :card_number, placeholder: :card_number, class: "form-control" %>
+        <%= f.text_field :card_operator, placeholder: :card_operator, class: "form-control" %>
+        <%= f.label :card_operator, t('.card_operator') %>
+      </div>
+      
+      <div class="form-floating mb-3">
+        <%= f.number_field :card_number, placeholder: :card_number, class: "form-control" %>
         <%= f.label :card_number, t('.card_number') %>
       </div>
       <div class="form-floating mb-3">

--- a/config/locales/payment_methods.pt-BR.yml
+++ b/config/locales/payment_methods.pt-BR.yml
@@ -20,6 +20,7 @@ pt-BR:
       card_holder_name: Nome do Titular
       cvv_number: Código de Segurança (CVV)
       expiry_date: Validade (MM/AA)
+      card_operator: Operadora
       submit: Enviar
       no_payment_methods_available: Não há formas de pagamento habilitadas
     create:

--- a/spec/support/apis/user_payment_methods/credit_card.json
+++ b/spec/support/apis/user_payment_methods/credit_card.json
@@ -4,6 +4,7 @@
     "payment_type": "credit_card",
     "card_number": "1234567890123456",
     "cvv_number": "123",
-    "expiry_date": "10/26"
+    "expiry_date": "10/26",
+    "card_operator": ""
   }
 }

--- a/spec/support/apis/user_payment_methods/invalid_credit_card.json
+++ b/spec/support/apis/user_payment_methods/invalid_credit_card.json
@@ -4,6 +4,7 @@
     "payment_type": "credit_card",
     "card_number": "",
     "cvv_number": "",
-    "expiry_date": ""
+    "expiry_date": "",
+    "card_operator": ""
   }
 }

--- a/spec/system/user/user_add_payment_method_spec.rb
+++ b/spec/system/user/user_add_payment_method_spec.rb
@@ -92,6 +92,7 @@ describe 'User add payment method' do
       click_link 'Cadastrar método de pagamento'
       within 'form' do
         select 'Cartão de Crédito', from: 'Tipo'
+        fill_in 'Operadora', with: ''
         fill_in 'Número do Cartão', with: ''
         fill_in 'Código de Segurança (CVV)', with: ''
         fill_in 'Validade (MM/AA)', with: ''


### PR DESCRIPTION
- O campo do `cvv_number`. Anteriormente era text_field agora é number_field

Também foi acrescentado:

- O campo `card_operator` no formulário de registro do cartão de crédito.

Para seguir as boas práticas, novos testes foram adicionados e outros foram corrigidos.